### PR TITLE
Keep css classes set via enum.ToString()

### DIFF
--- a/src/ThemesOfDotNet/wwwroot/css/site.css
+++ b/src/ThemesOfDotNet/wwwroot/css/site.css
@@ -118,19 +118,19 @@
     .gh-issue-kind-header.bottom-up {
         border-left-style: dashed;
     }
-
+/*! purgecss ignore */
     .gh-issue-kind-header.theme {
         border-color: purple;
     }
-
+/*! purgecss ignore */
     .gh-issue-kind-header.epic {
         border-color: #c6415a;
     }
-
+/*! purgecss ignore */
     .gh-issue-kind-header.userstory {
         border-color: #0e8a16;
     }
-
+/*! purgecss ignore */
     .gh-issue-kind-header.issue {
         border-color: darkgray;
     }


### PR DESCRIPTION
https://github.com/terrajobst/themesof.net/pull/9 was overzealous in stripping the `159kB` of css down to `19kB`; and removed classes that were programmatically declared via `@treeNode.Kind.ToString().ToLower()` as they didn't appear in the `.razor` or `.cshtml` files directly.

This marks them to be ignored in stripping using `/*! purgecss ignore */` which restores missed coloration.

From
![image](https://user-images.githubusercontent.com/1142958/108408217-ac484400-721c-11eb-8ba1-9d4389d2a30f.png)


To

![image](https://user-images.githubusercontent.com/1142958/108408197-a5b9cc80-721c-11eb-81be-172b93c275c3.png)
