### PR TITLE
Shave off ~10s from workflow by using built-in .NET5

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,11 +12,6 @@ jobs:
     - name: Get code
       uses: actions/checkout@v2
 
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
-
     # Publishing
 
     - name: dotnet publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,6 @@ jobs:
     - name: Get code
       uses: actions/checkout@v2
 
-    - name: Setup .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
-
     - name: dotnet build
       run: |
         cd src/ThemesOfDotNet


### PR DESCRIPTION
Explicitly installing a wildcard version of .NET5 means it almost always ends up taking ~10s (from latest builds) when that's not really needed, since it's already included in the hosted environments (see https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md#net-core-sdk).