### PR TITLE
Rotate icon while loading

### DIFF
--- a/src/ThemesOfDotNet/Shared/TreeListItem.razor
+++ b/src/ThemesOfDotNet/Shared/TreeListItem.razor
@@ -13,8 +13,9 @@
                         var visibleClass = node.Children.Count == 0 ? "invisible" : "";
                         var bottomUpClass = treeNode.IsBottomUp ? "bottom-up" : "";
                         var glyph = Owner.IsExpanded(node) ? "oi-minus" : "oi-plus";
+                        var allowFocus = !Owner.IsExpanded(node) ? "0" : null;
                     }
-                    <span class="oi @glyph tree-toggle @visibleClass" @onclick="() => Owner.ToggleNode(node)"></span>
+                    <span tabIndex="@allowFocus" class="oi @glyph tree-toggle @visibleClass" @onclick="() => Owner.ToggleNode(node)"></span>
                     <div class="gh-issue-kind-header @treeNode.Kind.ToString().ToLower() @bottomUpClass" />
                     <div>
                         <div>

--- a/src/ThemesOfDotNet/Shared/TreeListItem.razor
+++ b/src/ThemesOfDotNet/Shared/TreeListItem.razor
@@ -3,7 +3,10 @@
     <ul class="tree">
         @foreach (var node in Nodes)
         {
-            <li>
+            var isExpanded = Owner.IsExpanded(node);
+            var stateClass = isExpanded ? "node-open" : "node-closed";
+
+            <li class="@stateClass">
                 @{
                     var issueClass = Owner.IsMuted(node) ? "muted" : "";
                     var treeNode = node.TreeNode;
@@ -12,8 +15,8 @@
                     @{
                         var visibleClass = node.Children.Count == 0 ? "invisible" : "";
                         var bottomUpClass = treeNode.IsBottomUp ? "bottom-up" : "";
-                        var glyph = Owner.IsExpanded(node) ? "oi-minus" : "oi-plus";
-                        var allowFocus = !Owner.IsExpanded(node) ? "0" : null;
+                        var glyph = isExpanded ? "oi-minus" : "oi-plus";
+                        var allowFocus = !isExpanded ? "0" : null;
                     }
                     <span tabIndex="@allowFocus" class="oi @glyph tree-toggle @visibleClass" @onclick="() => Owner.ToggleNode(node)"></span>
                     <div class="gh-issue-kind-header @treeNode.Kind.ToString().ToLower() @bottomUpClass" />
@@ -63,7 +66,7 @@
                     </div>
                 </div>
 
-                @if (Owner.IsExpanded(node))
+                @if (isExpanded)
                 {
                     <TreeListItem Owner="@Owner" Nodes="@node.Children" />
                 }

--- a/src/ThemesOfDotNet/wwwroot/css/site.css
+++ b/src/ThemesOfDotNet/wwwroot/css/site.css
@@ -9,8 +9,15 @@
 .tree-toggle:before {
     display: inline-block;
 }
+.tree-toggle:focus {
+    outline: none;
+}
 .tree-toggle.oi-plus:focus:before {
     content: '\e08c';
+    color: darkgreen;
+    font-size: 1.4em;
+    font-weight: bold;
+    margin: -.1em 0 0 -.1em;
     animation: rotation 1.5s linear infinite;
 }
 

--- a/src/ThemesOfDotNet/wwwroot/css/site.css
+++ b/src/ThemesOfDotNet/wwwroot/css/site.css
@@ -30,6 +30,29 @@
         transform: rotate(-359deg);
     }
 }
+/*! purgecss ignore */
+.node-closed {
+    max-height: 102px;
+    overflow: hidden;
+}
+/*! purgecss ignore */
+.node-open {
+    max-height: unset;
+    animation: expand 0.5s ease-out;
+    overflow: hidden;
+}
+@keyframes expand {
+    0% {
+        max-height: 102px;
+    }
+    99% {
+        max-height: 600px;
+    }
+    100% {
+        max-height: unset;
+    }
+}
+
 .valid.modified:not([type=checkbox]) {
     outline: 1px solid #26b050;
 }
@@ -104,7 +127,7 @@
 
 .gh-details-cell {
     margin-top: 2px;
-    line-height: 1.25 !important;
+    line-height: 1.9 !important;
     font-size: 12px !important;
     color: #586069 !important;
 }
@@ -207,7 +230,6 @@
     border: 2px solid #ccc;
     border-radius: 4px;
     color: #ccc;
-    margin-left: -5px;
     margin-right: 5px;
     padding: 2px;
     font-size: 11px;

--- a/src/ThemesOfDotNet/wwwroot/css/site.css
+++ b/src/ThemesOfDotNet/wwwroot/css/site.css
@@ -6,6 +6,23 @@
     --dotnet-purple-border-hover: #3311BB;
 }
 
+.tree-toggle:before {
+    display: inline-block;
+}
+.tree-toggle.oi-plus:focus:before {
+    content: '\e08c';
+    animation: rotation 1.5s linear infinite;
+}
+
+@keyframes rotation {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(-359deg);
+    }
+}
 .valid.modified:not([type=checkbox]) {
     outline: 1px solid #26b050;
 }


### PR DESCRIPTION
If latency is high; nodes can take a little while to load. 

Change the `+` icon to a rotating load icon during this time:


https://user-images.githubusercontent.com/1142958/109394443-ef8e6b00-791e-11eb-93d5-49592398684f.mp4



