### PR TITLE
Update to ASP.NET Core 6 RTM

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Get .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.100-rc.2.21463.7'
+        dotnet-version: '6.0.102'
 
     - name: dotnet publish
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Get .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.100-rc.2.21463.7'
+        dotnet-version: '6.0.102'
 
     - name: dotnet build
       run: |

--- a/src/themesof.net/themesof.net.csproj
+++ b/src/themesof.net/themesof.net.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="5.0.1" />
+    <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="6.0.4" />
     <PackageReference Include="Humanizer.Core" Version="2.11.10" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />


### PR DESCRIPTION
Updates to the latest stable release of ASP.NET Core 6.

I noticed you weren't using a .NET 6-specific version of the GitHub OAuth package, and in checking whether that was because it wasn't on .NET 6 yet, saw it was still on RC2.
