### PR TITLE
Changed Id of FilterText Input Box

### DIFF
--- a/src/themesof.net/Shared/CompletionDialog.razor
+++ b/src/themesof.net/Shared/CompletionDialog.razor
@@ -12,7 +12,7 @@
             <div class="modal-body">
                 <div class="form-group">
                     <input @ref="_inputRef"
-                           id="lastName" class="form-control" placeholder="Filter"
+                           id="filterText" class="form-control" placeholder="Filter"
                            @bind="FilterText" @bind:event="oninput" @onkeydown="OnKeyDown"></input>
                     <div @ref="_completionListRef"
                          class="completion-list mt-1">


### PR DESCRIPTION
Some identifiers such as 'lastName' trigger Chrome's
autocomplete feature and force an annoying list of
last names you may have entered in previous sessions.